### PR TITLE
lint-staged 포멧팅 로직 설정에 json 파일 추가

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     }
   },
   "lint-staged": {
-    "*.{js,html,md}": [
+    "*.{js,html,md,json}": [
       "prettier --write",
       "git add"
     ]


### PR DESCRIPTION
### 무엇을 했나요?

pre-commit 깃훅에 실행되는 포멧팅 과정에 json 파일도 포함되도록 수정

### 왜 했나요?

커밋단계에서 자동으로 포멧팅 되는 파일 형식을 늘려 포멧팅에 신경을 덜 쓰기 위해